### PR TITLE
版本更新(BUG修复)

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,12 +48,12 @@ RxHttp是基于OkHttp的二次封装，并于RxJava做到无缝衔接，一条�
 
 ```java
 dependencies {
-   implementation 'com.rxjava.rxhttp:rxhttp:1.2.3'
-   annotationProcessor 'com.rxjava.rxhttp:rxhttp-compiler:1.2.3' //注解处理器，生成RxHttp类
+   implementation 'com.rxjava.rxhttp:rxhttp:1.2.4'
+   annotationProcessor 'com.rxjava.rxhttp:rxhttp-compiler:1.2.4' //注解处理器，生成RxHttp类
    implementation 'com.rxjava.rxlife:rxlife:1.1.0'  //页面销毁，关闭请求，非必须
 
    // if you use kotlin
-   kapt 'com.rxjava.rxhttp:rxhttp-compiler:1.2.3'
+   kapt 'com.rxjava.rxhttp:rxhttp-compiler:1.2.4'
 }
 ```
 

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -44,8 +44,8 @@ dependencies {
 
 //    implementation project(":rxhttp")
 //    kapt project(':rxhttp-compiler')
-    implementation 'com.rxjava.rxhttp:rxhttp:1.2.3'
-    kapt 'com.rxjava.rxhttp:rxhttp-compiler:1.2.3'
+    implementation 'com.rxjava.rxhttp:rxhttp:1.2.4'
+    kapt 'com.rxjava.rxhttp:rxhttp-compiler:1.2.4'
 
     implementation 'com.android.support:appcompat-v7:28.0.0'
     implementation 'com.android.support:recyclerview-v7:28.0.0'

--- a/rxhttp/src/main/java/rxhttp/wrapper/param/JsonParam.java
+++ b/rxhttp/src/main/java/rxhttp/wrapper/param/JsonParam.java
@@ -15,7 +15,7 @@ import rxhttp.wrapper.utils.GsonUtil;
  */
 public class JsonParam extends AbstractParam<JsonParam> {
 
-    public static final MediaType MEDIA_TYPE_JSON = MediaType.parse("application/json;charset=utf-8");
+    public static final MediaType MEDIA_TYPE_JSON = MediaType.parse("application/json; charset=utf-8");
 
     /**
      * @param url    请求路径


### PR DESCRIPTION
修复发送json请求content-type不对问题 原因：MediaType少了空格，更新到1.2.4版本